### PR TITLE
Update vvv-init.sh

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -30,6 +30,7 @@ if [[ ! -f "${VVV_PATH_TO_SITE}/public_html/wp-config.php" ]]; then
   echo "Configuring WordPress Stable..."
   noroot wp core config --dbname="${DB_NAME}" --dbuser=wp --dbpass=wp --quiet --extra-php <<PHP
 define( 'WP_DEBUG', true );
+define( 'SCRIPT_DEBUG', true );
 PHP
 fi
 


### PR DESCRIPTION
Since the WP_DEBUG is set to true by default, there is a reason why not to set SCRIPT_DEBUG to true too?

Because plugins use that constant to know if they must enqueue or not minified version of javascript/css files.

See for example WooCommerce: https://plugins.trac.wordpress.org/browser/woocommerce/trunk/includes/class-wc-frontend-scripts.php#L168