### PR TITLE
Avoid overwriting existing customizations to vvv-nginx.conf

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -52,7 +52,8 @@ else
   noroot wp core update --version="${WP_VERSION}"
 fi
 
-cp -f "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf.tmpl" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+# Copy over nginx config template, but don't overwrite existing config file on subsequent provisions
+cp -n "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf.tmpl" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
 
 if [ -n "$(type -t is_utility_installed)" ] && [ "$(type -t is_utility_installed)" = function ] && `is_utility_installed core tls-ca`; then
     sed -i "s#{{TLS_CERT}}#ssl_certificate /vagrant/certificates/${VVV_SITE_NAME}/dev.crt;#" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"


### PR DESCRIPTION
This PR introduces a small modification to the `vvv-init.sh` script.

A colleague of mine was having issues with edits to `vvv-nginx.conf` getting wiped out when reprovisioning VVV - so I changed the `cp` invocation to use the `-n` switch so `vvv-nginx.conf` will not be overwritten by `vvv-nginx.conf.tmpl` if it is already present. 