### PR TITLE
support for custom constants and values

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,5 +136,9 @@ custom:
          - query-monitor
          - https://github.com/crstauf/query-monitor-extend/archive/version/1.0.zip
          - https://github.com/norcross/airplane-mode/archive/master.zip
+    constants:
+		WP_DEBUG: true
+		WP_DEBUG_LOG: true
+		WP_DISABLE_FATAL_ERROR_HANDLER: true # To disable in WP 5.2 the FER mode
     locale: it_IT
 ```

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ custom:
          - query-monitor
          - https://github.com/crstauf/query-monitor-extend/archive/version/1.0.zip
          - https://github.com/norcross/airplane-mode/archive/master.zip
-    constants:
+    wpconfig_constants:
          WP_DEBUG: true
          WP_DEBUG_LOG: true
          WP_DISABLE_FATAL_ERROR_HANDLER: true # To disable in WP 5.2 the FER mode

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ custom:
          - https://github.com/crstauf/query-monitor-extend/archive/version/1.0.zip
          - https://github.com/norcross/airplane-mode/archive/master.zip
     constants:
-		WP_DEBUG: true
-		WP_DEBUG_LOG: true
-		WP_DISABLE_FATAL_ERROR_HANDLER: true # To disable in WP 5.2 the FER mode
+         WP_DEBUG: true
+         WP_DEBUG_LOG: true
+         WP_DISABLE_FATAL_ERROR_HANDLER: true # To disable in WP 5.2 the FER mode
     locale: it_IT
 ```

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -90,7 +90,7 @@ else
 fi
 
 
-cat test.yaml | shyaml get-values-0 sites.${SITE_ESCAPED}.custom.wpconfig_constants |
+get_config_value 'wpconfig_constants' |
   while IFS='' read -r -d '' key &&
         IFS='' read -r -d '' value; do
       noroot wp config set "${key}" "${value}" --raw

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -83,7 +83,7 @@ else
     sed -i "s#{{TLS_KEY}}##" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
 fi
 
-cat test.yaml | shyaml get-values-0 sites.${SITE_ESCAPED}.custom.constants |
+cat test.yaml | shyaml get-values-0 sites.${SITE_ESCAPED}.custom.wpconfig_constants |
   while IFS='' read -r -d '' key &&
         IFS='' read -r -d '' value; do
       noroot wp config set "${key}" "${value}" --raw

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -61,3 +61,9 @@ else
     sed -i "s#{{TLS_CERT}}##" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
     sed -i "s#{{TLS_KEY}}##" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
 fi
+
+cat test.yaml | shyaml get-values-0 sites.${SITE_ESCAPED}.custom.constants |
+  while IFS='' read -r -d '' key &&
+        IFS='' read -r -d '' value; do
+      noroot wp config set "${key}" "${value}" --raw
+  done


### PR DESCRIPTION
As #14 in this way we can have custom constants with also custom values!

```
boilerplate:
        repo: git@github.com:Varying-Vagrant-Vagrants/custom-site-template.git
        custom:
			constants:
				WP_DEBUG: true
				WP_DEBUG_LOG: true
				WP_DISABLE_FATAL_ERROR_HANDLER: true # To disable in WP 5.2 the FER mode
        nginx_upstream: php72
        hosts:
            - boilerplate.test
```