### PR TITLE
Skip nginx provisioning if it's already provisioned.

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -86,22 +86,27 @@ else
   echo "wp_type was set to none, provisioning WP was skipped, moving to Nginx configs"
 fi
 
-echo "Copying the sites Nginx config template ( fork this site template to customise the template )"
-cp -f "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf.tmpl" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
-
-if [ -n "$(type -t is_utility_installed)" ] && [ "$(type -t is_utility_installed)" = function ] && `is_utility_installed core tls-ca`; then
-  echo "Inserting the SSL key locations into the sites Nginx config"
-  VVV_CERT_DIR="/srv/certificates"
-  # On VVV 2.x we don't have a /srv/certificates mount, so switch to /vagrant/certificates
-  codename=$(lsb_release --codename | cut -f2)
-  if [[ $codename == "trusty" ]]; then # VVV 2 uses Ubuntu 14 LTS trusty
-    VVV_CERT_DIR="/vagrant/certificates"
-  fi
-  sed -i "s#{{TLS_CERT}}#ssl_certificate ${VVV_CERT_DIR}/${VVV_SITE_NAME}/dev.crt;#" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
-  sed -i "s#{{TLS_KEY}}#ssl_certificate_key ${VVV_CERT_DIR}/${VVV_SITE_NAME}/dev.key;#" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+if [ -f "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf" ]; then
+  echo "Nginx seems provisioned on ${VVV_SITE_NAME}. Provisioning nginx was skipped"
+  echo "If you want to reprovision nginx, please delete provision/vvv-nginx.conf on ${VVV_SITE_NAME}"
 else
+  echo "Copying the sites Nginx config template ( fork this site template to customise the template )"
+  cp -f "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf.tmpl" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+
+  if [ -n "$(type -t is_utility_installed)" ] && [ "$(type -t is_utility_installed)" = function ] && `is_utility_installed core tls-ca`; then
+    echo "Inserting the SSL key locations into the sites Nginx config"
+    VVV_CERT_DIR="/srv/certificates"
+    # On VVV 2.x we don't have a /srv/certificates mount, so switch to /vagrant/certificates
+    codename=$(lsb_release --codename | cut -f2)
+    if [[ $codename == "trusty" ]]; then # VVV 2 uses Ubuntu 14 LTS trusty
+      VVV_CERT_DIR="/vagrant/certificates"
+    fi
+    sed -i "s#{{TLS_CERT}}#ssl_certificate ${VVV_CERT_DIR}/${VVV_SITE_NAME}/dev.crt;#" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+    sed -i "s#{{TLS_KEY}}#ssl_certificate_key ${VVV_CERT_DIR}/${VVV_SITE_NAME}/dev.key;#" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+  else
     sed -i "s#{{TLS_CERT}}##" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
     sed -i "s#{{TLS_KEY}}##" "${VVV_PATH_TO_SITE}/provision/vvv-nginx.conf"
+  fi
 fi
 
 


### PR DESCRIPTION
This makes sure that any custom config that may exist on nginx is kept.