### PR TITLE
Check if the site is installed, and then attempt to restore from backup

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -42,6 +42,7 @@ PHP
   fi
 
   if ! $(noroot wp core is-installed); then
+    echo "WordPress is present but isn't installed to the database, checking for SQL dumps in wp-content/database.sql or the main backup folder."
     if [ -f "${VVV_PATH_TO_SITE}/public_html/wp-content/database.sql" ]; then
       echo "Found database backup on site directory. Installing site from there..."
       noroot wp config set DB_USER "wp"

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -41,24 +41,24 @@ define( 'SCRIPT_DEBUG', true );
 PHP
   fi
 
-  if [ -f "${VVV_PATH_TO_SITE}/public_html/wp-content/database.sql" ]; then
-    echo "Found database backup on site directory. Installing site from there..."
-    noroot wp config set DB_USER "wp"
-    noroot wp config set DB_PASSWORD "wp"
-    noroot wp config set DB_HOST "localhost"
-    noroot wp config set DB_NAME "${DB_NAME}"
-    noroot wp db import "${VVV_PATH_TO_SITE}/public_html/wp-content/database.sql"
-    echo "Installed database backup"
-  elif [ -f "/srv/database/backups/${VVV_SITE_NAME}.sql" ]; then
-    echo "Found database backup on the backups directory. Installing site from there..."
-    noroot wp config set DB_USER "wp"
-    noroot wp config set DB_PASSWORD "wp"
-    noroot wp config set DB_HOST "localhost"
-    noroot wp config set DB_NAME "${DB_NAME}"
-    noroot wp db import "/srv/database/backups/${VVV_SITE_NAME}.sql"
-    echo "Installed database backup"
-  else
-    if ! $(noroot wp core is-installed); then
+  if ! $(noroot wp core is-installed); then
+    if [ -f "${VVV_PATH_TO_SITE}/public_html/wp-content/database.sql" ]; then
+      echo "Found database backup on site directory. Installing site from there..."
+      noroot wp config set DB_USER "wp"
+      noroot wp config set DB_PASSWORD "wp"
+      noroot wp config set DB_HOST "localhost"
+      noroot wp config set DB_NAME "${DB_NAME}"
+      noroot wp db import "${VVV_PATH_TO_SITE}/public_html/wp-content/database.sql"
+      echo "Installed database backup"
+    elif [ -f "/srv/database/backups/${VVV_SITE_NAME}.sql" ]; then
+      echo "Found database backup on the backups directory. Installing site from there..."
+      noroot wp config set DB_USER "wp"
+      noroot wp config set DB_PASSWORD "wp"
+      noroot wp config set DB_HOST "localhost"
+      noroot wp config set DB_NAME "${DB_NAME}"
+      noroot wp db import "/srv/database/backups/${VVV_SITE_NAME}.sql"
+      echo "Installed database backup"
+    else
       echo "Installing WordPress Stable..."
 
       if [ "${WP_TYPE}" = "subdomain" ]; then


### PR DESCRIPTION
Potentially fix an issue when reprovisioning without restoring, which would install the database over and over again with the one from the backup.

This issue was introduced on #23.

On that PR @tomjn mentioned that the db_restore script already does this, and it's true tho I personally think this is a more elegant solution, which only restores the sites to be provisioned, whereas the restore script restores every sql file found on the backups directory.

If we agree on that, the restore script could be removed as this would make it unnecessary.