### PR TITLE
Set strict script execution for site provisioners

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Provision WordPress Stable
 
+set -euo pipefail
+
 echo " * Custom site template provisioner - downloads and installs a copy of WP stable for testing, building client sites, etc"
 
 # fetch the first host as the primary domain. If none is available, generate a default using the site name

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Provision WordPress Stable
 
-set -euo pipefail
+set -eo pipefail
 
 echo " * Custom site template provisioner - downloads and installs a copy of WP stable for testing, building client sites, etc"
 


### PR DESCRIPTION
Sets the script for stricter provisioning, [see this article for details on what these options mean and why](http://redsymbol.net/articles/unofficial-bash-strict-mode/).

With this change, failures in this site provisioner will allow the main site provisioner to detect failure.

Note that this will need extensive testing