### PR TITLE
Expire static assets after 100 days

### DIFF
--- a/provision/vvv-nginx-default.conf
+++ b/provision/vvv-nginx-default.conf
@@ -21,4 +21,8 @@ server {
     include      /etc/nginx/nginx-wp-common.conf;
 
     {{LIVE_URL}}
+    
+    location ~* \.(css|eot|gif|ico|jpeg|jpg|js|png|svg|tif|tiff|ttf|webp|woff|woff2)$ {
+        expires 100d;
+    }
 }


### PR DESCRIPTION
Adds an Expires: header for static assets.

Primary purpose is to silence the error in Lighthouse performance audits. 100 days seems to be the minimum to avoid the warning.

Previously: https://github.com/Varying-Vagrant-Vagrants/VVV/pull/2158