### PR TITLE
Is installed check should be with noroot

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -43,7 +43,7 @@ install_plugins() {
   WP_PLUGINS=$(get_config_value 'install_plugins' '')
   if [ ! -z "${WP_PLUGINS}" ]; then
     for plugin in ${WP_PLUGINS//- /$'\n'}; do
-      if [ ! $(wp plugin is-installed "${plugin}") ]; then
+      if [ ! $(noroot wp plugin is-installed "${plugin}") ]; then
         echo " * Installing and activating plugin: '${plugin}'"
         noroot wp plugin install "${plugin}" --activate
       else


### PR DESCRIPTION
Use noroot to check if plugin is installed.

Right now it gives [this](https://github.com/Varying-Vagrant-Vagrants/VVV/runs/1126237696?check_suite_focus=true#step:9:7) warning.