### PR TITLE
Generate wp-cli.yml, #1968

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -243,7 +243,7 @@ else
   cat <<EOF > "${PUBLIC_DIR_PATH}/wp-cli.yml"
 @${VVV_SITE_NAME}:
   ssh: vagrant@vvv.test
-  path: /srv/www/${VVV_SITE_NAME}/public_html
+  path: ${VVV_PATH_TO_SITE}
 EOF
 fi
 

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -240,6 +240,11 @@ else
   else
     update_wp
   fi
+  cat <<EOF > "${PUBLIC_DIR_PATH}/wp-cli.yml"
+@${VVV_SITE_NAME}:
+  ssh: vagrant@192.168.50.4
+  path: /srv/www/${VVV_SITE_NAME}/public_html
+EOF
 fi
 
 copy_nginx_configs

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -207,6 +207,12 @@ setup_cli() {
   else
     echo "path: \"public_html\"" > "${VVV_PATH_TO_SITE}/wp-cli.yml"
   fi
+  
+
+  cat <<EOF > "${PUBLIC_DIR_PATH}/wp-cli.yml"
+ssh: vagrant@vvv.test
+path: ${VVV_PATH_TO_SITE}
+EOF
 }
 
 cd "${VVV_PATH_TO_SITE}"
@@ -240,11 +246,6 @@ else
   else
     update_wp
   fi
-  cat <<EOF > "${PUBLIC_DIR_PATH}/wp-cli.yml"
-@${VVV_SITE_NAME}:
-  ssh: vagrant@vvv.test
-  path: ${VVV_PATH_TO_SITE}
-EOF
 fi
 
 copy_nginx_configs

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -242,7 +242,7 @@ else
   fi
   cat <<EOF > "${PUBLIC_DIR_PATH}/wp-cli.yml"
 @${VVV_SITE_NAME}:
-  ssh: vagrant@192.168.50.4
+  ssh: vagrant@vvv.test
   path: /srv/www/${VVV_SITE_NAME}/public_html
 EOF
 fi


### PR DESCRIPTION
Ref: https://github.com/Varying-Vagrant-Vagrants/VVV/issues/1968

Generate a file inside the public_html folder:

```
@site:
  ssh: vagrant@192.168.50.4
  path: /srv/www/site/public_html
```

Require the password that is `vagrant`, I didn't found any settings to specify it.
I am not expert of that file if there are other settings we want to insert anyway.