### PR TITLE
also add the sites name as a WP CLI alias

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -211,6 +211,9 @@ setup_cli() {
   echo "@vvv:" >> "${VVV_PATH_TO_SITE}/wp-cli.yml"
   echo "  ssh: vagrant@${DOMAIN}" >> "${VVV_PATH_TO_SITE}/wp-cli.yml"
   echo "  path: ${PUBLIC_DIR_PATH}" >> "${VVV_PATH_TO_SITE}/wp-cli.yml"
+  echo "@${VVV_SITE_NAME}:" >> "${VVV_PATH_TO_SITE}/wp-cli.yml"
+  echo "  ssh: vagrant@${DOMAIN}" >> "${VVV_PATH_TO_SITE}/wp-cli.yml"
+  echo "  path: ${PUBLIC_DIR_PATH}" >> "${VVV_PATH_TO_SITE}/wp-cli.yml"
 }
 
 cd "${VVV_PATH_TO_SITE}"


### PR DESCRIPTION
This should enable commands such as `wp @wordpress-one core version`