### PR TITLE
Fix nginx configs when there are spaces in the paths

### DIFF
--- a/provision/vvv-nginx-default.conf
+++ b/provision/vvv-nginx-default.conf
@@ -2,11 +2,11 @@ server {
     listen       80;
     listen       443 ssl http2;
     server_name  {vvv_hosts};
-    root         {vvv_path_to_site}{vvv_public_dir};
+    root         "{vvv_path_to_site}{vvv_public_dir}";
 
     # Nginx logs
-    error_log    {vvv_path_to_site}/log/nginx-error.log;
-    access_log   {vvv_path_to_site}/log/nginx-access.log;
+    error_log    "{vvv_path_to_site}/log/nginx-error.log";
+    access_log   "{vvv_path_to_site}/log/nginx-access.log";
 
     # This is needed to set the PHP being used
     set          $upstream {upstream};


### PR DESCRIPTION
This site should be able to reproduce the issue:

```yaml
  christian delecluse:
    description: "My website"
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    hosts:
      - cdelecluse.test
```

Hopefully switching to this branch will correct it:

```yaml
  christian delecluse:
    description: "My website"
    repo: https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    branch: "fix/spaces-in-paths"
    hosts:
      - cdelecluse.test
```

Related to https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2459