### PR TITLE
Improved adding constants on wp-config.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The Nginx configuration for this site can be overriden by creating a `provision/
 | `install_themes`         |                            | A list/array of themes to install. Similar to the hosts array. These values are passed to the WP CLI plugin install command and take the same format.                                                                                                                              |
 | `site_title`             | The first host of the site | The main name/title of the site, defaults to `sitename.test`                                                                                                                                                                                                                       |
 | `wp_type`                | `single`                   |  - `single` will create a standard WP install<br> - `subdomain` will create a subdomain multisite<br> - `subdirectory` will create a subdirectory multisite<br> - `none` will skip installing WordPress, and let you install WordPress manually (useful for custom folder layouts) |
-| `wp_version`             | `latest`                   | The version of WordPress to install if no installation is present                                                                                                                                                                                                                  |
+| `wp_version`             | `latest`                   | The version of WordPress to install if no installation is present    |
+| `wpconfig_constants`     |                            | A list/array of constants with their value to add to the wp-config.php   |
 
 
 ## Examples

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -153,7 +153,7 @@ download_wordpress() {
 
 initial_wpconfig() {
   echo " * Setting up wp-config.php"
-  noroot wp core config --dbname="${DB_NAME}" --dbprefix="${DB_PREFIX}" --dbuser=wp --dbpass=wp
+  noroot wp config create --dbname="${DB_NAME}" --dbprefix="${DB_PREFIX}" --dbuser=wp --dbpass=wp
   noroot wp config set WP_DEBUG true --raw
   noroot wp config set SCRIPT_DEBUG true --raw
 }

--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -153,10 +153,9 @@ download_wordpress() {
 
 initial_wpconfig() {
   echo " * Setting up wp-config.php"
-  noroot wp core config --dbname="${DB_NAME}" --dbprefix="${DB_PREFIX}" --dbuser=wp --dbpass=wp  --extra-php <<PHP
-define( 'WP_DEBUG', true );
-define( 'SCRIPT_DEBUG', true );
-PHP
+  noroot wp core config --dbname="${DB_NAME}" --dbprefix="${DB_PREFIX}" --dbuser=wp --dbpass=wp
+  noroot wp config set WP_DEBUG true --raw
+  noroot wp config set SCRIPT_DEBUG true --raw
 }
 
 maybe_import_test_content() {


### PR DESCRIPTION
WP-CLI has the command to add the constants and it is better because in this way avoid to add multiple times the constants.
I got a report that the constant was added again but it wasn't able to replicate but looking at the code the only way that could happen is on that function