### PR TITLE
fix nginx http2 warnings

### DIFF
--- a/provision/vvv-nginx-default.conf
+++ b/provision/vvv-nginx-default.conf
@@ -1,6 +1,7 @@
 server {
     listen       80;
-    listen       443 ssl http2;
+    listen       443 ssl;
+    http2 on;
     server_name  {vvv_hosts};
     root         "{vvv_path_to_site}{vvv_public_dir}";
 
@@ -10,9 +11,6 @@ server {
 
     # This is needed to set the PHP being used
     set          $upstream {upstream};
-
-    # Enable server push if SSL/HTTP2 is being used for link preload headers
-    http2_push_preload on;
 
     {vvv_tls_cert}
     {vvv_tls_key}


### PR DESCRIPTION
This fixes 2 warnings that show up when processing nginx configs on the latest nginx versions that get provisioned