### PR TITLE
Add slash to nginx server root

### DIFF
--- a/provision/vvv-nginx-default.conf
+++ b/provision/vvv-nginx-default.conf
@@ -3,7 +3,7 @@ server {
     listen       443 ssl;
 
     server_name  {vvv_hosts};
-    root         "{vvv_path_to_site}{vvv_public_dir}";
+    root         "{vvv_path_to_site}/{vvv_public_dir}";
 
     # Nginx logs
     error_log    "{vvv_path_to_site}/log/nginx-error.log";


### PR DESCRIPTION
`vvv_path_to_site` shouldn't have a trailing slash, if it did the error and access log would be broken, as would parts of the provisioner

Fixes https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2729