### PR TITLE
Fix working directory

### DIFF
--- a/provision/vvv-init.sh
+++ b/provision/vvv-init.sh
@@ -38,6 +38,9 @@ function setup_nginx_folders() {
   noroot mkdir -p "${VVV_PATH_TO_SITE%/}/log"
   noroot touch "${VVV_PATH_TO_SITE%/}/log/nginx-error.log"
   noroot touch "${VVV_PATH_TO_SITE%/}/log/nginx-access.log"
+}
+
+function setup_public_dir() {
   echo " * Creating the public folder at '${PUBLIC_DIR}' if it doesn't exist already"
   noroot mkdir -p "${PUBLIC_DIR_PATH}"
 }
@@ -263,11 +266,16 @@ function setup_cli() {
   echo "  path: ${PUBLIC_DIR_PATH}" >> "${VVV_PATH_TO_SITE%/}/wp-cli.yml"
 }
 
-cd "${PUBLIC_DIR_PATH}"
+# initial working directory
+cd "${VVV_PATH_TO_SITE}"
 
-setup_cli
 setup_database
 setup_nginx_folders
+setup_public_dir
+setup_cli
+
+# Start working inside WP public_dir
+cd "${PUBLIC_DIR_PATH}"
 
 if [ "${WP_TYPE}" == "none" ]; then
   echo " * wp_type was set to none, provisioning WP was skipped, moving to Nginx configs"


### PR DESCRIPTION
Issue: Public dir path accessed before it's created

Error output
```shell
==> default: Running provisioner: site-wordpress-one (shell)...
    default: Running: /tmp/vagrant-shell20241019-195569-y25ltc.sh
    default:  ▷ Running the 'site-wordpress-one' provisioner...
    default:  * Pulling down the master branch of https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git
    default:  * Downloading wordpress-one provisioner, git cloning from https://github.com/Varying-Vagrant-Vagrants/custom-site-template.git into /srv/www/wordpress-one
    default: Cloning into '/srv/www/wordpress-one'...
    default:  * wordpress-one provisioner clone successful
    default: vvv-init.sh: line 266: cd: /srv/www/wordpress-one/public_html: No such file or directory
```

- Specify separate function to setup public directory
- Improve setup orders: `setup_cli` wp-cli isn't needed until we start installing WP